### PR TITLE
Fixed state issues in FieldEdit and TextEdit

### DIFF
--- a/src/components/Builder/Builder.tsx
+++ b/src/components/Builder/Builder.tsx
@@ -14,6 +14,7 @@ import {closestCenter, DndContext, useSensor, PointerSensor, KeyboardSensor} fro
 import {SortableContext, verticalListSortingStrategy} from "@dnd-kit/sortable";
 import Errors, {ErrorType, GetError} from "../Errors/Errors";
 import {Theme, useTheme} from "@mui/material/styles";
+import EditModal from "../Items/EditModal";
 
 export type BuilderOptions = {
     Actions?: ActionFC[],
@@ -46,7 +47,7 @@ export type BuilderProps = {
 
 const Builder = ({ Items, SetItems, Options }: BuilderProps) => {
     const [items, setItems] = useState<AnyItem[]>(Items || [])
-    const [modal, setModal] = useState( <></>)
+    const [modal, setModal] = useState( false )
     const [item, setItem] = useState({id:'x', type:'test'} as AnyItem)
     const sensors = [
         useSensor(PointerSensor),
@@ -54,10 +55,6 @@ const Builder = ({ Items, SetItems, Options }: BuilderProps) => {
     ]
     const defaultTheme = useTheme()
 
-    // const AllowedSubtypes: AllowedSubtypes = {...(Options?.AllowedSubtypes || DefaultSubtypes()), ...(Options?.AdditionalSubtypes || {})}
-    // const AllowedItems:AllowedItems = {...(Options?.AllowedItems || DefaultItems()), ...(Options?.AdditionalItems || {})}
-    // const MyActions:ActionFC[] = [Transfer, Save, Clear]
-        //{...(Options?.Actions || [Transfer, Save, Clear]), ...(Options?.ActionsAppend || [] as FC<ActionProps>[])}
     const options:Options = {...(Options || {}),
         Actions: [Transfer, Save, Clear],
         AllowedSubtypes: {...(Options?.AllowedSubtypes || DefaultSubtypes()), ...(Options?.AdditionalSubtypes || {})},
@@ -80,21 +77,6 @@ const Builder = ({ Items, SetItems, Options }: BuilderProps) => {
         console.log('ITEM',item)
         setItems(SetItem(item, items))
     },[item])
-
-    // const activeItem = useMemo(
-    //     () => items.find((item) => item.id === active?.id),
-    //     [items, active?.id]
-    // );
-
-    // useEffect(() => {
-    //     if(SetItems) {
-    //         SetItems(items)
-    //     }
-    // }, [items])
-    //
-    // useEffect(()=>{
-    //     setItems(SetItem(item, items))
-    // },[item])
 
     return <div className='builder'>
         <Actions Items={items} Options={options}/>
@@ -132,7 +114,7 @@ const Builder = ({ Items, SetItems, Options }: BuilderProps) => {
                     </Grid>
                 </Grid>
             </DndContext>
-            {modal}
+            <EditModal showModal={modal} item={item} items={items} options={options}></EditModal>
         </Box>
 
     </div>

--- a/src/components/Items/EditFC.tsx
+++ b/src/components/Items/EditFC.tsx
@@ -1,5 +1,5 @@
-import React, {ChangeEvent, useEffect, useState} from "react";
-import {AnyItem, GroupItem, isGroup, ItemProps, NamedItem} from "./Items";
+import React, {ChangeEvent, useState} from "react";
+import {AnyItem, isGroup, ItemProps, NamedItem} from "./Items";
 import {FormGroup, FormHelperText, Stack, TextField} from "@mui/material";
 import {ShowErrors} from "./Subtypes";
 
@@ -36,8 +36,8 @@ export const validateNameChange = (props: ItemProps, newName?: string): validate
     const otherNames = getSiblingItems(item, items)
         .filter(itm => {
             if (!isNamedItem(itm)) return false
-            if (itm.id === item.id) return false
-            return true
+            return itm.id !== item.id;
+
         })
         .flatMap(itm => { if (isNamedItem(itm)) return itm.name })
 
@@ -57,25 +57,20 @@ function isNamedItem(item: AnyItem): item is NamedItem {
     return 'name' in item && item.name !== undefined
 }
 
-const NamedItemEdit = (ItemProps: ItemProps) => {
-    if(!isNamedItem(ItemProps.item)) {
+const NamedItemEdit = ({item, items, options}: ItemProps) => {
+    if(!isNamedItem(item)) {
         return <></>
     }
 
-    const [item, setItem] = useState(ItemProps.item)
     const [nameError, setNameError] = useState(false)
     const [nameErrors, setNameErrors] = useState([] as string[])
     const [validNameHint, setValidNameHint] = useState<string>()
-
-    useEffect(() => {
-        ItemProps.options.SetItem(item)
-    }, [item])
 
     const onNameChange = (event: ChangeEvent<HTMLInputElement>) => {
         if (!isNamedItem(item)) return
 
         const { target: { value } } = event;
-        const {validName, errors} = validateNameChange({...ItemProps, item: item}, value)
+        const {validName, errors} = validateNameChange({item: item, items: items, options: options}, value)
 
         if (errors !== undefined) {
             setNameError(true)
@@ -95,7 +90,8 @@ const NamedItemEdit = (ItemProps: ItemProps) => {
 
             setNameError(false)
             setNameErrors([])
-            setItem(itm)
+
+            options.SetItem(itm)
         }
     }
 

--- a/src/components/Items/EditModal.tsx
+++ b/src/components/Items/EditModal.tsx
@@ -2,31 +2,41 @@ import React from "react";
 import {ItemProps, NamedItem} from "./Items";
 import {Button, Dialog, DialogActions, DialogContent, DialogTitle} from "@mui/material";
 import EditFC from "./EditFC";
-const EditModal = (itemProps: ItemProps) => {
+
+type EditModalProps = ItemProps & {showModal: boolean}
+const EditModal = (itemProps: EditModalProps) => {
+
     const Close = () => {
         if(itemProps.options.setModal != null) {
-            itemProps.options.setModal(<></>)
+            itemProps.options.setModal(false)
         }
     }
-    console.log('md', itemProps.item.id)
-    return <>
-        <Dialog
-            maxWidth="lg"
-            fullWidth={true}
-            open={true}
-            onClose={Close}
-            aria-labelledby="example-modal-sizes-title-lg"
-            disableEnforceFocus={true}
-        >
-            <DialogTitle>Edit {(itemProps.item as NamedItem)?.name} {itemProps.item.type} ({itemProps.item.id}) </DialogTitle>
-            <DialogContent>
-                <EditFC {...itemProps}/>
-            </DialogContent>
-            <DialogActions>
-                <Button color="secondary" onClick={Close}>Close</Button>
-            </DialogActions>
-        </Dialog>
-    </>
+    // console.log('md', itemProps.item.id)
+
+    if(itemProps.showModal) {
+        return <>
+            <Dialog
+                maxWidth="lg"
+                fullWidth={true}
+                open={true}
+                onClose={Close}
+                aria-labelledby="example-modal-sizes-title-lg"
+                disableEnforceFocus={true}
+            >
+                <DialogTitle>Edit {(itemProps.item as NamedItem)?.name} {itemProps.item.type} ({itemProps.item.id}) </DialogTitle>
+                <DialogContent>
+                    <EditFC item={itemProps.item} items={itemProps.items} options={itemProps.options}/>
+                </DialogContent>
+                <DialogActions>
+                    <Button color="secondary" onClick={Close}>Close</Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    } else {
+        return <></>
+    }
+
+
 }
 
 export default EditModal

--- a/src/components/Items/Field/FieldEdit.tsx
+++ b/src/components/Items/Field/FieldEdit.tsx
@@ -8,16 +8,15 @@ import {
     FormHelperText, InputLabel,
     MenuItem,
     Select,
-    SelectChangeEvent, Stack,
+    SelectChangeEvent,
     TextField
 } from "@mui/material";
 import {omit, pick} from "lodash";
 
-export const FieldEdit = (FieldProps: ItemProps) => {
-    if (!isField(FieldProps.item)) return <></>
+export const FieldEdit = ({item, items, options}: ItemProps) => {
+    if (!isField(item)) return <></>
 
-    const [item, setItem] = useState(FieldProps.item)
-    const [subtype, setSubtype] = useState(FieldProps.item.subtype)
+    const [subtype, setSubtype] = useState(item.subtype)
 
     const subtypeInit = useRef(false)
     const subtypeOptions = Object.keys(DefaultSubtypes())
@@ -26,20 +25,17 @@ export const FieldEdit = (FieldProps: ItemProps) => {
         // Don't run getSubtypeDefaults on first render. Trust that existing subtype fields are correct.
         if(subtypeInit.current) {
             const fieldItem = getSubtypeDefaults(item, subtype)
-            setItem(fieldItem)
+            // setItem(fieldItem)
+            options.SetItem(fieldItem)
         } else {
             subtypeInit.current = true
         }
     }, [subtype])
 
-    useEffect(() => {
-        FieldProps.options.SetItem(item)
-    }, [item])
-
     const getSubtypeDefaults = (item: FieldProps['item'], subtype: string) => {
         const itm = { ...item }
         itm.subtype = subtype
-        const defaults = FieldProps.options.AllowedSubtypes[subtype].Subtype
+        const defaults = options.AllowedSubtypes[subtype].Subtype
         const fieldIndex: (keyof FieldItem)[] = ['id', 'type', 'label', 'name', 'subtype', 'required', 'deprecated']
 
         // grab field-specific properties from ITEM
@@ -61,7 +57,7 @@ export const FieldEdit = (FieldProps: ItemProps) => {
                 delete itm.required
             }
 
-            setItem(itm)
+            options.SetItem(itm)
         },
         deprecated: (event: ChangeEvent<HTMLInputElement>) => {
             const itm = { ...item }
@@ -72,7 +68,8 @@ export const FieldEdit = (FieldProps: ItemProps) => {
                 itm.deprecated = undefined
                 delete itm.deprecated
             }
-            setItem(itm)
+
+            options.SetItem(itm)
         },
         subtype: (event: SelectChangeEvent) => {
             const { target: { value } } = event;
@@ -82,13 +79,15 @@ export const FieldEdit = (FieldProps: ItemProps) => {
             const itm = { ...item }
             const { target: { value } } = event;
             itm.label = value
-            setItem(itm)
+
+            options.SetItem(itm)
         },
         helperText: (event: ChangeEvent<HTMLInputElement>) => {
             const itm = { ...item }
             const { target: { value } } = event;
             itm.helperText = value
-            setItem(itm)
+
+            options.SetItem(itm)
         }
     }
 
@@ -148,12 +147,12 @@ export const FieldEdit = (FieldProps: ItemProps) => {
             </FormHelperText>
         </FormControl>
 
-        { Object.entries(FieldProps.options.AllowedSubtypes).map(([key, value]) => {
+        { Object.entries(options.AllowedSubtypes).map(([key, value]) => {
             return subtype === key &&
                 <value.EditFC
                     item={item}
-                    items={FieldProps.items}
-                    options={FieldProps.options}
+                    items={items}
+                    options={options}
                 ></value.EditFC>
         })}
 

--- a/src/components/Items/Items.tsx
+++ b/src/components/Items/Items.tsx
@@ -18,7 +18,7 @@ export type Options = {
     onSave?: (Items: AnyItem[]) => void,
     SetItem: Dispatch<SetStateAction<AnyItem>>,
     setItems: Dispatch<SetStateAction<AnyItem[]>>,
-    setModal?: Dispatch<SetStateAction<JSX.Element>>,
+    setModal?: Dispatch<SetStateAction<boolean>>,
     IsBuild: boolean,
     getError: (error: string, item: AnyItem) => string|undefined,
     searchableOptions?: {

--- a/src/components/Items/ShowItem.tsx
+++ b/src/components/Items/ShowItem.tsx
@@ -5,7 +5,6 @@ import FormatLineSpacingRoundedIcon from "@mui/icons-material/FormatLineSpacingR
 import ModeRoundedIcon from '@mui/icons-material/ModeRounded';
 import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
 import DeleteForeverRoundedIcon from '@mui/icons-material/DeleteForeverRounded';
-import EditModal from './EditModal'
 import ItemFC from "./ItemFC";
 import {SortableItem, DragHandle} from "../SortableItem";
 import Filter from "../Filter/Filter";
@@ -14,49 +13,40 @@ type ShowItemsProps = ItemProps & {
     key?: string|number
 }
 
-export const ShowItem = ({item, items, options}: ShowItemsProps) => {
-    const itemProps: ItemProps = {
-        items: items,
-        item: item,
-        options: options
+export const ShowItem = ({item, items, options, key}: ShowItemsProps) => {
+
+    if (options.IsBuild) {
+        const openModal = () => {
+            options.SetItem(item)
+            if(options.setModal) {
+                options.setModal(true)
+            }
+        }
+
+        return (
+            <SortableItem key={item.id} id={item.id}>
+                <DragHandle>
+                    <FormatLineSpacingRoundedIcon sx={{ fontSize: 'large', verticalAlign:'center', m: 1 }} />
+                </DragHandle>
+                <Box component="div" sx={{ flexGrow: 1 }}>
+                    { ItemFC({item: item, items: items, options: options})}
+                </Box>
+                <ModeRoundedIcon sx={{ fontSize: 'large', verticalAlign:'center', m: 1 }} onClick={openModal}/>
+                <ContentCopyRoundedIcon sx={{ fontSize: 'large', verticalAlign:'center', m: 1 }} />
+                <DeleteForeverRoundedIcon sx={{ fontSize: 'large', verticalAlign:'center', m: 1 }} />
+            </SortableItem>
+        )
     }
 
-    // @ts-ignore
-
-
-        if (options.IsBuild) {
-            const openModal = (ItemProps: ItemProps) => {
-                console.log('ItemProps', ItemProps)
-                console.log('IP', ItemProps)
-                if(options.setModal) {
-                    options.setModal(<EditModal {...ItemProps} />)
-                }
-            }
-
-            return (
-                <SortableItem key={item.id} id={item.id}>
-                    <DragHandle>
-                        <FormatLineSpacingRoundedIcon sx={{ fontSize: 'large', verticalAlign:'center', m: 1 }} />
-                    </DragHandle>
-                    <Box component="div" sx={{ flexGrow: 1 }}>
-                        { ItemFC(itemProps)}
-                    </Box>
-                    <ModeRoundedIcon sx={{ fontSize: 'large', verticalAlign:'center', m: 1 }} onClick={()=>openModal(itemProps)}/>
-                    <ContentCopyRoundedIcon sx={{ fontSize: 'large', verticalAlign:'center', m: 1 }} />
-                    <DeleteForeverRoundedIcon sx={{ fontSize: 'large', verticalAlign:'center', m: 1 }} />
-                </SortableItem>
-            )
-        }
-
-        if (isField(item) && item.deprecated) {
-            return <></>
-        }
-        if (!Filter(item, items, item.filter)) {
-            return <></>
-        }
-        return <>
-            <ItemFC {...itemProps}/>
-        </>
+    if (isField(item) && item.deprecated) {
+        return <></>
+    }
+    if (!Filter(item, items, item.filter)) {
+        return <></>
+    }
+    return <>
+        <ItemFC item={item} items={items} options={options}/>
+    </>
 
 }
 

--- a/src/components/Items/Subtypes/Text/TextEdit.tsx
+++ b/src/components/Items/Subtypes/Text/TextEdit.tsx
@@ -1,24 +1,19 @@
-import React, {ChangeEvent, useEffect, useState} from "react";
+import React, {ChangeEvent, useState} from "react";
 import {FieldProps, isText} from "../../Items";
 import {TextField, Checkbox, FormGroup, FormControlLabel, FormHelperText} from "@mui/material";
 import ShowErrors from "../ShowErrors";
 
-export const TextEdit = (FieldProps: FieldProps ) => {
-    if (!isText(FieldProps.item)){
+export const TextEdit = ({item, items, options}: FieldProps ) => {
+    if (!isText(item)){
         return <></>
     }
 
-    const [item, setItem] = useState(FieldProps.item)
     const [valueError, setValueError] = useState( false)
     const [valueErrors, setValueErrors] = useState( [] as string[])
     const [minLengthError, setMinLengthError] = useState({error: false})
     const [minLengthErrors, setMinLengthErrors] = useState( [] as string[])
     const [maxLengthError, setMaxLengthError] = useState( false)
     const [maxLengthErrors, setMaxLengthErrors] = useState( [] as string[])
-
-    useEffect(() => {
-        FieldProps.options.SetItem(item)
-    }, [item])
 
     const onChangeMinLength = (event: ChangeEvent<HTMLInputElement>) => {
 
@@ -36,7 +31,7 @@ export const TextEdit = (FieldProps: FieldProps ) => {
             }
         }
 
-        setItem({...item, minLength: value})
+        options.SetItem({...item, minLength: value})
         setMinLengthError({error: false})
         setMinLengthErrors([]);
     }
@@ -55,7 +50,8 @@ export const TextEdit = (FieldProps: FieldProps ) => {
                 return
             }
         }
-        setItem({...item, maxLength: value})
+
+        options.SetItem({...item, maxLength: value})
         setMaxLengthError(false);
         setMaxLengthErrors([]);
     }
@@ -81,7 +77,7 @@ export const TextEdit = (FieldProps: FieldProps ) => {
         }
         setValueError(false)
         setValueErrors([])
-        setItem(itm)
+        options.SetItem(itm)
     }
 
     const onClickMultiline = (event: ChangeEvent<HTMLInputElement>) => {
@@ -92,7 +88,7 @@ export const TextEdit = (FieldProps: FieldProps ) => {
         } else {
             st.multiline = true
         }
-        setItem(st)
+        options.SetItem(st)
     }
 
     return <>


### PR DESCRIPTION
Removed 'item' state variable from EditFC, FieldEdit and TextEdit components. Refactored ShowItem and EditModal to allow prop updates from Builder to correctly propagate through component tree.