### PR TITLE
Use lodash cloneDeep to copy item for change events. 

### DIFF
--- a/src/components/Items/Subtypes/Checkbox/CheckboxST.tsx
+++ b/src/components/Items/Subtypes/Checkbox/CheckboxST.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {CheckboxProps, CheckboxSubtype} from "../../Items";
+import {CheckboxProps} from "../../Items";
 import {
     Checkbox,
     FormControlLabel,
@@ -8,16 +8,13 @@ import {
     InputLabel, Stack
 } from "@mui/material";
 import {CheckboxValidate} from "./index";
+import {cloneDeep} from "lodash";
 
 const CheckboxST = ({item, options}: CheckboxProps ) => {
     function onChange(index: number){
-        const itm = {...item} as CheckboxSubtype;
+        const itm = cloneDeep(item)
         itm.options[index].selected = !itm.options[index].selected;
-        // itm.value = itm.options.filter(i => {return i.selected ?? false}).map(i => {return i.value ?? i.label});
-        // if (itm.value?.length === 0) {
-        //     itm.value = undefined
-        //     delete itm.value
-        // }
+
         CheckboxValidate(itm, options)
 
         if (!options.IsBuild) {

--- a/src/components/Items/Subtypes/Radio/RadioST.tsx
+++ b/src/components/Items/Subtypes/Radio/RadioST.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import {
-    RadioProps,
-    RadioSubtype
+    RadioProps
 } from "../../Items";
 import {
     FormControlLabel,
@@ -11,11 +10,12 @@ import {
     RadioGroup, Stack
 } from "@mui/material";
 import {RadioValidate} from "./index";
+import {cloneDeep} from "lodash";
 
 const RadioST = ({item, options}: RadioProps ) => {
 
     function onChange(index: number){
-        const itm = {...item} as RadioSubtype
+        const itm = cloneDeep(item)
         const curVal = itm.options[index].selected
         itm.options.map((option, index) => {
             itm.options[index].selected = false;

--- a/src/components/Items/Subtypes/Select/SelectST.tsx
+++ b/src/components/Items/Subtypes/Select/SelectST.tsx
@@ -11,8 +11,9 @@ import {
     Stack
 } from '@mui/material';
 import { Theme, useTheme } from '@mui/material/styles';
-import {Option, SelectProps, SelectSubtype} from '../../Items';
+import { SelectProps } from '../../Items';
 import { SelectValidate } from "./index";
+import { cloneDeep } from "lodash";
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
@@ -28,8 +29,7 @@ const MenuProps = {
 function SelectST({item, options}: SelectProps) {
     const theme = useTheme();
     const handleChange = (event: SelectChangeEvent<string | string[]>) => {
-        const itm = { ...item } as SelectSubtype
-        itm.options = itm.options.map(option => { return {...option} as Option})
+        const itm = cloneDeep(item)
         const { target: { value } } = event;
 
         if (itm.multiples) {


### PR DESCRIPTION
Fixes nested objects not being copied correctly by spread operator.